### PR TITLE
Освобождение памяти по forth->rp0

### DIFF
--- a/src/forth.c
+++ b/src/forth.c
@@ -37,6 +37,7 @@ void forth_free(struct forth *forth)
 {
     free(forth->sp0);
     free(forth->memory);
+    free(forth->rp0);
     *forth = (struct forth) {0};
 }
 


### PR DESCRIPTION
При вызове функции forth_free не освобождается память стека возвратов, в итоге получается утечка